### PR TITLE
Fixed 'null' error when 'header.name' is a directory

### DIFF
--- a/utilities.js
+++ b/utilities.js
@@ -90,7 +90,7 @@ export async function extractArchiveTo(packageBuffer, target, {virtualPath = 0} 
     return new Promise((resolve, reject) => {
 
         function map(header) {
-            header.name = getFileName(header.name, virtualPath);
+            header.name = getFileName(header.name, virtualPath) || header.name;
             return header;
         }
 


### PR DESCRIPTION
When 'header.name' is a directory, just like 'package', getFileName() return 'null'.'tar-fs' will throw 'null' error on 'string.replace' method due to that.